### PR TITLE
User supplied key points

### DIFF
--- a/bigstream/affine.py
+++ b/bigstream/affine.py
@@ -39,6 +39,12 @@ def ransac_affine(
         if verbose:
             ns = fix_spots.shape[0]
             print(f'FIXED image: found {ns} key points')
+    else:
+        # Not sure what the convention should be for pixel vs. physical coordinates.
+        # This is assuming pixels at the same resolution as `fix` and `mov`.
+        fix_spots = features.cull_boundary_points(fix_spots, cc_radius, fix.shape)
+        if fix_spots.shape[1]==3:
+            fix_spots = np.hstack([fix_spots, np.ones((fix_spots.shape[0],1))])
 
     if mov_spots is None:
         mov_spots = features.blob_detection(
@@ -52,7 +58,11 @@ def ransac_affine(
         if verbose:
             ns = mov_spots.shape[0]
             print(f'MOVING image: found {ns} key points')
-
+    else:
+        mov_spots = features.cull_boundary_points(mov_spots, cc_radius, mov.shape)
+        if mov_spots.shape[1]==3:
+            mov_spots = np.hstack([mov_spots, np.ones((mov_spots.shape[0], 1))])
+            
     # sort
     sort_idx = np.argsort(fix_spots[:, 3])[::-1]
     fix_spots = fix_spots[sort_idx, :3][:nspots]

--- a/bigstream/features.py
+++ b/bigstream/features.py
@@ -90,3 +90,13 @@ def match_points(A, B, scores, threshold):
     # return positions of corresponding points
     return a_pos[keeps, :3], b_pos[best_indcs[keeps], :3]
 
+def cull_boundary_points(points, distance, volshape, offset=[0,0,0]):
+    """
+    Only retain points farther than distance from the edges of volume with shape volshape
+    """
+    upperlim = [i-distance for i in volshape]
+    lowerlim = [distance for i in volshape]
+    keep_lows = np.all(points[:,0:3] - offset > lowerlim, axis=1)
+    keep_highs = np.all(points[:,0:3] - offset + 1 < upperlim, axis=1)
+    idx = np.argwhere(keep_highs & keep_lows)
+    return np.squeeze(points[idx,:])


### PR DESCRIPTION
This PR supplies the function `transform.cull_boundary_points` to remove points from a user supplied list that are closer than `cc_radius` to the volume boundary. It has been tested on synthetic data and found to reproduce the output of `affine.ransac_affine` for a global transform. Further work is needed to implement its use in the local affine procedures, namely using the supplied `offset` parameter to reduce the point list for each block.