### PR TITLE
Patch for edge case: moving block can be outside moving image domain

### DIFF
--- a/bigstream/align.py
+++ b/bigstream/align.py
@@ -1426,6 +1426,16 @@ def alignment_pipeline(
         deformable align: a tuple with the bspline parameters and the
         vector field with shape equal to fix.shape + (3,)
     """
+
+    # check default case
+    if fix is None or mov is None:
+        ndim = len(fix_spacing)
+        default = np.eye(ndim + 1)
+        if 'deform' in [x[0] for x in steps]:
+            shape = fix.shape if fix is not None else mov.shape
+            default = np.zeros(shape + (ndim,), dtype=np.float32)
+        return default
+
     # define how to run alignment functions
     a = (fix, mov, fix_spacing, mov_spacing)
     b = {'fix_mask':fix_mask, 'mov_mask':mov_mask,

--- a/bigstream/piecewise_align.py
+++ b/bigstream/piecewise_align.py
@@ -314,7 +314,7 @@ def distributed_piecewise_alignment_pipeline(
     
             ################ Read fix and moving data ########################
             fix = fix_zarr[fix_slices]
-            mov = mov_zarr[mov_slices]
+            mov = mov_zarr[mov_slices] if np.all(mov_stop > 0) else None  # edge case: mov block outside domain
             fix_mask, mov_mask = fix_mask_zarr, mov_mask_zarr
             if isinstance(fix_mask_zarr, zarr.core.Array):
                 ratio = np.array(fix_mask_zarr.shape) / fix_zarr.shape
@@ -327,7 +327,7 @@ def distributed_piecewise_alignment_pipeline(
                 start = np.round( ratio * mov_start ).astype(int)
                 stop = np.round( ratio * mov_stop ).astype(int)
                 mov_mask_slices = tuple(slice(a, b) for a, b in zip(start, stop))
-                mov_mask = mov_mask_zarr[mov_mask_slices]
+                mov_mask = mov_mask_zarr[mov_mask_slices] if np.all(stop > 0) else None
             ##################################################################
     
             ################ Parse steps #####################################
@@ -339,9 +339,10 @@ def distributed_piecewise_alignment_pipeline(
     
             ############################ Align ###############################
             # run alignment pipeline
+            mov_shape = mov.shape if mov is not None else 0
             logger.info(f'Compute block transform' +
                         f'{block_index}: {fix_slices}, {mov_origin}' +
-                        f'fix shape: {fix.shape}, mov_shape: {mov.shape}' +
+                        f'fix shape: {fix.shape}, mov_shape: {mov_shape}' +
                         f'{static_transform_list}')
             transform = alignment_pipeline(
                 fix, mov, fix_spacing, mov_spacing, steps,


### PR DESCRIPTION
If distributed_piecewise_alignment_pipeline is called with a non-empty static_transform_list, the fixed block coordinates have to be transformed through all transforms in static_transform_list to determine the corresponding moving image block coordinates. When static_transform_list contains a transform, or a combination of transforms, that moves the moving image substantially, it is possible that a fixed image block will have no corresponding region in the moving image, that is, the corresponding moving image block would be entirely outside the moving image domain. Basically, this means the fixed image contains a region of data that the moving image does not (assuming the transforms in static_transform_list are correct).

To fix this, I added a hidden default flag to align.alignment_pipeline. If either fix or mov is None then the alignment_pipeline returns the identity transform. I also modified piecewise_align.distributed_piecewise_alignment_pipeline to check if any of the moving block end coordinates are negative. This would indicate that the region of moving image that corresponds to the fixed block is outside the moving image domain. In this case, instead of attempting (and failing) to read from the moving image zarr, we set mov to None. Everything else works the same way, but when alignment_pipeline sees mov=None, it immediately returns an identity transform.