### PR TITLE
ensuring one shard per worker for sharded zarr arrays. 

### DIFF
--- a/bigstream/distutils.py
+++ b/bigstream/distutils.py
@@ -71,9 +71,10 @@ def _check_storage_unit_size(label, unit_shape, processing_block_size, reverse_o
 
 def validate_processing_block_size(output_array, processing_block_size, reverse_output_axes=False):
     """
-    Verify that the output zarr chunk size does not exceed the processing
-    block size. If chunks are larger than blocks, concurrent workers may
-    write to the same zarr chunk, causing race conditions.
+    Verify that the output zarr chunk size, and shard size when sharded,
+    does not exceed the processing block size. If chunks/shards are larger
+    than blocks, concurrent workers may write to the same zarr chunk/shard,
+    causing race conditions.
 
     Parameters
     ----------
@@ -86,19 +87,13 @@ def validate_processing_block_size(output_array, processing_block_size, reverse_
     Raises
     ------
     ValueError
-        If any spatial chunk dimension exceeds the corresponding block dimension.
+        If any spatial chunk or shard dimension exceeds the corresponding block dimension.
     """
     if output_array is None or not hasattr(output_array, 'chunks'):
         return
 
-    output_chunks = np.array(get_spatial_values(output_array.chunks, reverse_axes=reverse_output_axes))
-    if np.any(output_chunks > processing_block_size):
-        logger.error((
-            f'Output zarr chunk size {output_chunks} exceeds '
-            f'block partition size {processing_block_size}. '
-            f'This may cause race conditions during write.'
-        ))
-        raise ValueError(
-            f'Processing block size {processing_block_size} is too small '
-            f'compared to chunk size: {output_array.chunks}'
-        )
+    _check_storage_unit_size('chunk', output_array.chunks, processing_block_size, reverse_output_axes)
+
+    output_shards = getattr(output_array, 'shards', None)
+    if output_shards is not None:
+        _check_storage_unit_size('shard', output_shards, processing_block_size, reverse_output_axes)

--- a/bigstream/distutils.py
+++ b/bigstream/distutils.py
@@ -55,6 +55,20 @@ class ThrottledArraySliceReader:
             self.semaphore.release()
 
 
+def _check_storage_unit_size(label, unit_shape, processing_block_size, reverse_output_axes):
+    unit = np.array(get_spatial_values(unit_shape, reverse_axes=reverse_output_axes))
+    if np.any(unit > processing_block_size):
+        logger.error((
+            f'Output zarr {label} size {unit} exceeds '
+            f'block partition size {processing_block_size}. '
+            f'This may cause race conditions during write.'
+        ))
+        raise ValueError(
+            f'Processing block size {processing_block_size} is too small '
+            f'compared to {label} size: {unit_shape}'
+        )
+
+
 def validate_processing_block_size(output_array, processing_block_size, reverse_output_axes=False):
     """
     Verify that the output zarr chunk size does not exceed the processing

--- a/bigstream/tools/main_local_align_pipeline.py
+++ b/bigstream/tools/main_local_align_pipeline.py
@@ -651,6 +651,9 @@ def _align_local_data(fix_image: ImageData,
             zarr_format=zarr_format,
             shard_shape=align_shard_size,
         )
+        # each worker must own a whole shard, not just a chunk, to avoid
+        # unsynchronized writes into a shard shared with another worker
+        align_processing_size = getattr(align, 'shards', None) or align_chunk_size
         logger.info(f'Apply static transforms {static_transforms}' +
                     f'and local transform {deformfield_path}:{deformfield_subpath}' +
                     f'to warp {mov_image} -> {align_path}:{align_subpath}')
@@ -667,7 +670,7 @@ def _align_local_data(fix_image: ImageData,
             np.array(get_spatial_values(fix_image.voxel_spacing)) / fix_image.expansion_factor,
             mov_image,
             np.array(get_spatial_values(mov_image.voxel_spacing)) / mov_image.expansion_factor,
-            align_chunksize, # use block chunk size for distributing work
+            align_processing_size, # shard-sized block for distributing work
             static_transforms + deform_transforms, # transform_list
             cluster_client,
             overlap_factor=transform_overlap_factor,

--- a/tests/test_distutils.py
+++ b/tests/test_distutils.py
@@ -15,3 +15,11 @@ def test_unsharded_block():
     """Block size matching chunk size on an unsharded array is fine."""
     output = _FakeOutputArray(chunks=(64, 64, 64))
     validate_processing_block_size(output, np.array([64, 64, 64]))
+
+
+def test_processing_block_is_chunksize():
+    """Chunk-sized block on a sharded array must be rejected: multiple such
+    blocks can land in the same shard with no synchronization."""
+    output = _FakeOutputArray(chunks=(64, 64, 64), shards=(256, 256, 256))
+    with pytest.raises(ValueError, match='shard size'):
+        validate_processing_block_size(output, np.array([64, 64, 64]))

--- a/tests/test_distutils.py
+++ b/tests/test_distutils.py
@@ -23,3 +23,9 @@ def test_processing_block_is_chunksize():
     output = _FakeOutputArray(chunks=(64, 64, 64), shards=(256, 256, 256))
     with pytest.raises(ValueError, match='shard size'):
         validate_processing_block_size(output, np.array([64, 64, 64]))
+
+
+def test_processing_block_is_shardsize():
+    """Shard-sized block on a sharded array is fine: each block owns a whole shard."""
+    output = _FakeOutputArray(chunks=(64, 64, 64), shards=(256, 256, 256))
+    validate_processing_block_size(output, np.array([256, 256, 256]))

--- a/tests/test_distutils.py
+++ b/tests/test_distutils.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+from bigstream.distutils import validate_processing_block_size
+
+
+class _FakeOutputArray:
+
+    def __init__(self, chunks, shards=None):
+        self.chunks = chunks
+        self.shards = shards
+
+
+def test_unsharded_block():
+    """Block size matching chunk size on an unsharded array is fine."""
+    output = _FakeOutputArray(chunks=(64, 64, 64))
+    validate_processing_block_size(output, np.array([64, 64, 64]))


### PR DESCRIPTION
## Summary

Fixes a data-loss race condition in the local alignment pipeline's transform-application step when writing to a sharded zarr v3 output array.

`distributed_apply_transform` was being called with `align_chunksize` (the zarr **chunk** size) as its dask blocksize. For an unsharded output that's fine -- one worker per chunk-file, no overlap. But once sharding groups several chunks into one shard, a shard (not the chunk) becomes the real atomic write unit: writing part of a shard requires zarr to read the whole shard, merge in the new chunk, and rewrite the whole shard (`ShardingCodec._encode_partial_single`). With multiple chunk-sized dask blocks landing in the same shard and no synchronization between workers, one worker's write can silently overwrite another's already-written chunk.

`validate_processing_block_size` exists specifically to catch "block too small" configurations like this, but it only ever checked the output's chunk size, not its shard size, so this exact configuration passed validation unflagged.

## Changes

- **`bigstream/distutils.py`**: `validate_processing_block_size` now also checks the output array's shard size (when sharded), not just its chunk size. Extracted the shared compare/log/raise logic into `_check_storage_unit_size` to avoid duplicating it between the chunk and shard checks.
- **`bigstream/tools/main_local_align_pipeline.py`**: `_align_local_data` now passes a shard-sized block to `distributed_apply_transform` (`getattr(align, 'shards', None) or align_chunk_size`) instead of the raw chunk-sized `align_chunksize`, so each worker owns a whole shard and no two workers can ever write into the same one.
- **`tests/test_distutils.py`** (new): unit tests for `validate_processing_block_size` covering the unsharded case, the unsafe chunk-sized-block-on-sharded-array case, and the safe shard-sized-block case.

## Test plan

- [x] `tests/test_distutils.py::test_unsharded_block` -- unsharded array, block == chunk size, no error (existing behavior preserved)
- [x] `tests/test_distutils.py::test_processing_block_is_chunksize` -- sharded array, chunk-sized block, now correctly raises `ValueError`
- [x] `tests/test_distutils.py::test_processing_block_is_shardsize` -- sharded array, shard-sized block, no error
